### PR TITLE
Prevent "dictionary changed size during iteration" error

### DIFF
--- a/lvcache/lvm.py
+++ b/lvcache/lvm.py
@@ -93,7 +93,7 @@ class LogicalVolume(object):
 
         status = dict(zip(cache_status_fields,
                           status.strip().split()[:len(cache_status_fields)]))
-        for k in status.keys():
+        for k in list(status.keys()):
             if status[k].isdigit():
                 status[k] = int(status[k])
             elif '/' in status[k]:


### PR DESCRIPTION
In Python 3, this will return a generator. When the subsequent code modifies the list being operated on, it will trigger a RuntimeError.
By using `list()` we force a copy of the list to be made.