### PR TITLE
Added --yes to final cache creation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.py[co]
 *.egg-info
 setup.cfg
+/build/
+/dist/

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>lvcache</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.python.pydev.PyDevBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.python.pydev.pythonNature</nature>
+	</natures>
+</projectDescription>

--- a/.pydevproject
+++ b/.pydevproject
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?eclipse-pydev version="1.0"?><pydev_project>
+<pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
+<path>/${PROJECT_DIR_NAME}</path>
+</pydev_pathproperty>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python interpreter</pydev_property>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
+</pydev_project>

--- a/lvcache/cmd_create.py
+++ b/lvcache/cmd_create.py
@@ -7,7 +7,7 @@ from . import lvm
 
 
 def adjust_512(num):
-    return 512 * (num/512)
+    return 512 * int(num/512)
 
 
 class Create(Command):

--- a/lvcache/lvm.py
+++ b/lvcache/lvm.py
@@ -111,7 +111,7 @@ class LogicalVolume(object):
             self.log.info(line.strip())
 
     def attach_cache_pool(self, cache_lv):
-        lvconvert('--type', 'cache',
+        lvconvert('--yes', '--type', 'cache',
                   '--cachepool', '%s/%s' % (cache_lv.vg.name,
                                             cache_lv.name),
                   '%s/%s' % (self.vg.name, self.name))

--- a/lvcache/lvm.py
+++ b/lvcache/lvm.py
@@ -93,7 +93,7 @@ class LogicalVolume(object):
 
         status = dict(zip(cache_status_fields,
                           status.strip().split()[:len(cache_status_fields)]))
-        for k in status.keys():
+        for k in list(status.keys()):
             if status[k].isdigit():
                 status[k] = int(status[k])
             elif '/' in status[k]:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='lvcache',
-    version='1.0.1',
+    version='1.0.2',
     description='Wrapper for creating cached LVM logical volumes',
     author='Lars Kellogg-Stedman',
     author_email='lars@oddbit.com',


### PR DESCRIPTION
Experimenting with caching, I found "create" to be hanging. When you create a new cache volume and reuse space that has previously been used as cache (I had executed a `remove` immediately before the `create`), `lvconvert` prompts with:
`Do you want wipe existing metadata of cache pool test/test_cache? [y/n]:`
which causes the execution to hang.

As `lvcache` has created volume `test_cache` in the steps leading to the final convert, any existing metadata can savely be wiped.
